### PR TITLE
Handle paginated submissions and download PDFs

### DIFF
--- a/apparator/utils/github_sync.py
+++ b/apparator/utils/github_sync.py
@@ -1,0 +1,17 @@
+"""Utility helpers for committing files to a Git repository."""
+
+from pathlib import Path
+from subprocess import run, CalledProcessError
+from typing import Iterable
+
+
+def commit_files(repo_path: Path, files: Iterable[Path], message: str) -> None:
+    """Stage ``files`` inside ``repo_path`` and create a commit."""
+
+    str_files = [str(Path(f)) for f in files]
+    try:
+        run(["git", "-C", str(repo_path), "add", *str_files], check=True)
+        run(["git", "-C", str(repo_path), "commit", "-m", message], check=True)
+    except CalledProcessError as exc:
+        raise RuntimeError(f"git command failed: {exc}") from exc
+

--- a/manual_test.py
+++ b/manual_test.py
@@ -17,6 +17,11 @@ def main():
         for s in subs[:5]:
             print("   •", s["title"], "→", s["url"])
 
+        if subs:
+            print("→ Fetching first submission…")
+            details = hr.fetch_submission(subs[0], download_dir=".")
+            print("Downloaded:", details.get("pdf"))
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/process_submissions.py
+++ b/scripts/process_submissions.py
@@ -1,0 +1,51 @@
+"""Example script to process new HackerRank submissions."""
+
+import json
+from pathlib import Path
+
+from apparator.core.browser import with_browsers
+from apparator.handlers.hackerrank import HackerRankHandler
+from apparator.config import get_config
+from apparator.utils.github_sync import commit_files
+
+
+STATE_FILE = Path("submissions.json")
+PROBLEMS_DIR = Path("problems")
+
+
+def load_state() -> list:
+    if STATE_FILE.exists():
+        return json.loads(STATE_FILE.read_text())
+    return []
+
+
+def save_state(data: list) -> None:
+    STATE_FILE.write_text(json.dumps(data, indent=2))
+
+
+def main() -> None:
+    cfg = get_config()
+    known = load_state()
+    known_urls = {e["url"] for e in known}
+
+    with with_browsers(headless=False) as bm:
+        page = bm.new_page()
+        hr = HackerRankHandler(page, cfg)
+        hr.login()
+        submissions = hr.list_submissions()
+
+        new_entries = [s for s in submissions if s["url"] not in known_urls]
+        for entry in new_entries:
+            folder = PROBLEMS_DIR / entry["title"].replace(" ", "_")
+            folder.mkdir(parents=True, exist_ok=True)
+            details = hr.fetch_submission(entry, download_dir=str(folder))
+            (folder / "solution.txt").write_text(details["solution"])
+            if details.get("pdf"):
+                commit_files(Path("."), [folder], f"Add {entry['title']}")
+
+        save_state(submissions)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- support traversing multiple submission pages on HackerRank
- download the statement PDF in `fetch_submission`
- provide a helper to create git commits
- demo new processing logic in `process_submissions.py`
- update `manual_test.py` to try downloading the first submission

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_685c11c836c483218adaa60b57e79ef0