### PR TITLE
Add project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Apparator
+
+Apparator is a small prototype for programmatically collecting coding challenge submissions. It uses [Playwright](https://playwright.dev/) to drive a browser and log in to sites such as HackerRank. Site specific logic lives in "handler" classes that implement a common interface. The included `HackerRankHandler` shows how to log in, list submissions and fetch individual solutions.
+
+The `BrowserManager` context in `apparator/core/browser.py` manages launching Chromium, Firefox and WebKit instances. Handler classes derive from `SiteHandler` in `apparator/core/handler_base.py` which defines the basic workflow of `login`, `list_submissions` and `fetch_submission`.
+
+## Required configuration
+
+Credentials and tokens are loaded from a `.env` file at the project root. Use `config/.env.example` as a template:
+
+```dotenv
+# HackerRank credentials
+HR_USER=your_hackerrank_username
+HR_PASS=your_hackerrank_password
+
+# GitHub token (with repo scope)
+GH_TOKEN=ghp_XXXXXXXXXXXXXXXXXXXX
+```
+
+At runtime the values are accessed in `apparator/config.py` as `HR_USER`, `HR_PASS` and `GH_TOKEN`.
+
+## Installation
+
+Create a virtual environment and install dependencies:
+
+```bash
+python -m venv env
+source env/bin/activate
+pip install playwright python-dotenv pytest
+playwright install
+```
+
+## Running the scripts
+
+After setting up your `.env` file you can run one of the provided scripts:
+
+* `scripts/process_submissions.py` – iterates over your submissions and processes them (implementation not included in this prototype).
+* `manual_test.py` – simple demo that logs in and prints the first few submissions.
+
+Example:
+
+```bash
+python manual_test.py
+```
+
+Both scripts expect the environment variables shown above to be present.


### PR DESCRIPTION
## Summary
- document project purpose, configuration, and usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_685c14616d248321a4e1f51e6ac27df6