### PR TITLE
Increase login timeout for slower hackerrank redirects

### DIFF
--- a/apparator/handlers/hackerrank.py
+++ b/apparator/handlers/hackerrank.py
@@ -27,8 +27,9 @@ class HackerRankHandler(SiteHandler):
         # Click the submit button
         self.page.click("button[type=submit]")
         # Wait until redirected to dashboard
+        # allow more time here in case the redirect takes a while
         self.page.wait_for_url(
-            "https://www.hackerrank.com/dashboard", timeout=20000)
+            "https://www.hackerrank.com/dashboard", timeout=60000)
 
     def list_submissions(self) -> List[Dict[str, Any]]:
         """Return a list of all submissions across every page."""


### PR DESCRIPTION
## Summary
- wait longer in `HackerRankHandler.login()` to handle slow dashboard redirects
- add a brief comment noting the extended timeout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_685cf5545c848321a9b62cad657f72d0