### PR TITLE
Implement auth utilities

### DIFF
--- a/apparator/utils/auth.py
+++ b/apparator/utils/auth.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import Dict
+from dotenv import load_dotenv
+from playwright.sync_api import Browser, BrowserContext
+
+# Paths
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+ENV_FILE = PROJECT_ROOT / ".env"
+SESSION_FILE = PROJECT_ROOT / "playwright_state.json"
+
+
+def load_credentials(env_path: Path = ENV_FILE) -> Dict[str, str]:
+    """Load credentials from environment or a ``.env`` file."""
+    if env_path.exists():
+        load_dotenv(dotenv_path=env_path)
+    return {
+        "HR_USER": os.getenv("HR_USER", ""),
+        "HR_PASS": os.getenv("HR_PASS", ""),
+        "GH_TOKEN": os.getenv("GH_TOKEN", ""),
+    }
+
+
+def load_session(browser: Browser, storage_path: Path = SESSION_FILE, **kwargs) -> BrowserContext:
+    """Return a new context using saved Playwright storage if available."""
+    if storage_path.exists():
+        return browser.new_context(storage_state=str(storage_path), **kwargs)
+    return browser.new_context(**kwargs)
+
+
+def save_session(context: BrowserContext, storage_path: Path = SESSION_FILE) -> None:
+    """Persist the given context's storage state."""
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    context.storage_state(path=str(storage_path))
+
+
+def clear_session(storage_path: Path = SESSION_FILE) -> None:
+    """Remove any saved storage state."""
+    if storage_path.exists():
+        storage_path.unlink()

--- a/scripts/reset_cookies.py
+++ b/scripts/reset_cookies.py
@@ -1,0 +1,18 @@
+"""Utility script to remove any saved Playwright session data."""
+from pathlib import Path
+import shutil
+from apparator.utils.auth import SESSION_FILE, clear_session
+
+
+def main() -> None:
+    # Remove stored storage_state file
+    clear_session()
+
+    # Delete any persistent browser data directories if present
+    user_data_dir = Path("playwright")
+    if user_data_dir.exists():
+        shutil.rmtree(user_data_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- load credentials and manage session cookies via `utils.auth`
- add utility to wipe saved Playwright cookies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d767cbecc832195cef16fbbdcd9da