### PR TITLE
Improve HackerRank test coverage

### DIFF
--- a/tests/test_hackerrank.py
+++ b/tests/test_hackerrank.py
@@ -6,7 +6,11 @@ import re
 
 def load_handler():
     """Import HackerRankHandler with a minimal Playwright stub if needed."""
-    if importlib.util.find_spec("playwright") is None:
+    try:
+        spec = importlib.util.find_spec("playwright")
+    except ValueError:
+        spec = None
+    if spec is None and "playwright" not in sys.modules:
         sync_api = types.ModuleType("playwright.sync_api")
         sync_api.Page = object
         sys.modules.setdefault("playwright", types.ModuleType("playwright"))
@@ -78,4 +82,83 @@ def test_list_submissions_pagination():
     results = hr.list_submissions()
     assert len(results) == 2
     assert page.gotos == [1, 2]
+
+
+class DummyDownload:
+    def __init__(self):
+        self.saved_to = None
+
+    def save_as(self, path):
+        self.saved_to = path
+
+
+class DummyFetchPage:
+    def __init__(self):
+        self.goto_urls = []
+        self.clicked = []
+        self.waited = []
+        self.selectors = {}
+        self.download = DummyDownload()
+
+    def goto(self, url, wait_until=None, timeout=None):
+        self.goto_urls.append(url)
+
+    def query_selector(self, selector):
+        return self.selectors.get(selector)
+
+    def wait_for_selector(self, selector):
+        self.waited.append(selector)
+
+    def click(self, selector):
+        self.clicked.append(selector)
+
+    def expect_download(self):
+        page = self
+
+        class Ctx:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, exc_type, exc_val, exc_tb):
+                pass
+
+            @property
+            def value(self_inner):
+                return page.download
+
+        return Ctx()
+
+
+def make_fetch_page():
+    page = DummyFetchPage()
+    page.selectors[".challenge-heading"] = DummyElement("Challenge")
+    page.selectors[".challenge-description"] = DummyElement("Statement")
+    page.selectors[".editor-content"] = DummyElement("print('hi')")
+    return page
+
+
+def test_fetch_submission_no_download():
+    HackerRankHandler = load_handler()
+    page = make_fetch_page()
+    hr = HackerRankHandler(page, {})
+    result = hr.fetch_submission({"url": "https://example.com"})
+    assert result == {
+        "title": "Challenge",
+        "statement": "Statement",
+        "solution": "print('hi')",
+        "pdf": None,
+    }
+    assert page.goto_urls == ["https://example.com"]
+
+
+def test_fetch_submission_download_pdf(tmp_path):
+    HackerRankHandler = load_handler()
+    page = make_fetch_page()
+    hr = HackerRankHandler(page, {})
+    result = hr.fetch_submission({"url": "https://example.com"}, download_dir=str(tmp_path))
+    expected_pdf = str(tmp_path / "Challenge.pdf")
+    assert result["pdf"] == expected_pdf
+    assert page.download.saved_to == expected_pdf
+    assert page.waited == ["a:has-text('Download Problem Statement')"]
+    assert page.clicked == ["a:has-text('Download Problem Statement')"]
 

--- a/tests/test_hackerrank_handler.py
+++ b/tests/test_hackerrank_handler.py
@@ -10,6 +10,8 @@ from apparator.config import get_config
 #@pytest.mark.skip("needs real credentials and is an integration test")
 def test_hackerrank_list_submissions():
     config = get_config()
+    if not config.get("HR_USER") or not config.get("HR_PASS"):
+        pytest.skip("HackerRank credentials not configured")
     with with_browsers(headless=False) as bm:
         page = bm.new_page()
         hr = HackerRankHandler(page, config)


### PR DESCRIPTION
## Summary
- add fetch_submission tests using dummy page
- skip integration tests if HackerRank credentials missing
- fix `load_handler` when `playwright` is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d768042fc8321abf9b7ce0ae65b62